### PR TITLE
Update slide.tsx to remove require cycle warning

### DIFF
--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -16,7 +16,7 @@ import Animated, {
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
-import { Bubble, BubbleRef } from './';
+import { Bubble, BubbleRef } from './balloon';
 import { palette } from './theme/palette';
 import { clamp } from './utils';
 const formatSeconds = (second: number) => `${Math.round(second * 100) / 100}`;


### PR DESCRIPTION
This should remove the require cycle warning.

I currently get this error:
```
Require cycle: node_modules/react-native-awesome-slider/src/index.ts -> node_modules/react-native-awesome-slider/src/slide.tsx -> node_modules/react-native-awesome-slider/src/index.ts
```