### PR TITLE
ThumbIndex is wrong in some slider width

### DIFF
--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -613,7 +613,6 @@ export const Slider: FC<AwesomeSliderProps> = ({
         testID={testID}
         style={[styles.view, { height: sliderHeight }, style]}
         hitSlop={panHitSlop}
-        key={`${step}${maximumValue.value}${minimumValue.value}`}
         onLayout={onLayout}>
         <Animated.View
           style={StyleSheet.flatten([

--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -563,10 +563,11 @@ export const Slider: FC<AwesomeSliderProps> = ({
         .map((_, i) => Math.round(width.value * (i / step)));
 
       // current positon width
-      const currentWidth =
+      const currentWidth = Math.round(
         ((progress.value - minimumValue.value) /
           (maximumValue.value - minimumValue.value)) *
-        width.value;
+          width.value,
+      );
 
       const currentIndex = marksLeft.findIndex(value => value >= currentWidth);
       return clamp(currentIndex, 0, step);

--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -613,6 +613,7 @@ export const Slider: FC<AwesomeSliderProps> = ({
         testID={testID}
         style={[styles.view, { height: sliderHeight }, style]}
         hitSlop={panHitSlop}
+        key={`${step}${maximumValue.value}${minimumValue.value}`}
         onLayout={onLayout}>
         <Animated.View
           style={StyleSheet.flatten([


### PR DESCRIPTION
Based on slider width, sometimes thumbIndex will be wrong. To fix this issue I wrapped currentWidth in a `Math.round` because we are using same method for finding steps width.