### PR TITLE
fix: track and thumb are now in sync while using disableTrackFollow prop

### DIFF
--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -611,7 +611,7 @@ export const Slider: FC<AwesomeSliderProps> = ({
       }
       const currentValue =
         (progress.value / (minimumValue.value + maximumValue.value)) *
-        width.value;
+        (width.value - (disableTrackFollow ? thumbWidth : 0));
       return clamp(currentValue, 0, width.value - thumbWidth);
     },
     data => {


### PR DESCRIPTION
Fixes https://github.com/alantoa/react-native-awesome-slider/issues/19