### PR TITLE
fix: fix initial value for stepped slider

### DIFF
--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -253,6 +253,7 @@ export const Slider: FC<AwesomeSliderProps> = memo(function Slider({
   thumbWidth = 15,
   snapToStep = true,
 }) {
+  const snappingEnabled = snapToStep && step;
   const bubbleRef = useRef<BubbleRef>(null);
 
   const isScrubbingInner = useSharedValue(false);
@@ -263,14 +264,12 @@ export const Slider: FC<AwesomeSliderProps> = memo(function Slider({
   const thumbValue = useSharedValue(0);
   const bubbleOpacity = useSharedValue(0);
   const markLeftArr = useSharedValue<number[]>([]);
-  const thumbIndex = useSharedValue(snapToStep && step ? progress.value - 1 : 0);  
+  const thumbIndex = useSharedValue(snappingEnabled ? progress.value - 1 : 0);
   const isTriggedHaptic = useSharedValue(false);
   const _theme = {
     ...defaultTheme,
     ...theme,
   };
-
-  const snappingEnabled = snapToStep && step;
 
   const sliderTotalValue = useDerivedValue(() => {
     'worklet';

--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -263,7 +263,7 @@ export const Slider: FC<AwesomeSliderProps> = memo(function Slider({
   const thumbValue = useSharedValue(0);
   const bubbleOpacity = useSharedValue(0);
   const markLeftArr = useSharedValue<number[]>([]);
-  const thumbIndex = useSharedValue(0);
+  const thumbIndex = useSharedValue(snapToStep && step ? progress.value - 1 : 0);  
   const isTriggedHaptic = useSharedValue(false);
   const _theme = {
     ...defaultTheme,


### PR DESCRIPTION
`thumbIndex` was only updated within the gesture callback, but it is used to set the slider index, so its initial value was not being set.


closes #46 
closes #47 