### PR TITLE
fix: prevent thumbValue to be NaN

### DIFF
--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -799,7 +799,7 @@ export const Slider: FC<AwesomeSliderProps> = memo(function Slider({
       return clamp(currentValue, 0, width.value - thumbWidth);
     },
     (data) => {
-      if (data !== undefined) {
+      if (data !== undefined && !isNaN(data) {
         thumbValue.value = data;
       }
     },


### PR DESCRIPTION
After update react-native-reanimated to lates varsion (3.11.0) react-native-awesome-slider started to crash because thumbValue sometimes can be NaN.

Added check if data is also NaN other then undefined only
![Screenshot 2024-05-08 at 13 58 53](https://github.com/alantoa/react-native-awesome-slider/assets/19978874/e5e95fce-4704-4325-a23f-ed5fb45cc27a)
